### PR TITLE
Allow users to provide their own `logMissingTranslation` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,20 @@
 const i18nContext = React.createContext(null)
 
+const defaultLogMissingTranslation = ({ language, path }) => { 
+  console.console.warn(`Missing translation (${language}): ${path}`)
+}
+
 export function useI18n(...i18nPathSegments) {
   const context = React.useContext(i18nContext)
   if (context === null) throwMissingContextError()
-  const { value, language } = context
+  const { value, language, logMissingTranslation } = context
   
   return (...pathSegments) => {
     const path = [...i18nPathSegments, ...pathSegments].join('.')
     const result = normalize(language, getProp(value, path))
 
     if (process.env.NODE_ENV !== 'production' && typeof result === 'undefined') {
-      console.warn(`Missing translation (${language}): %c${path}`, 'font-weight: bold;')
+      logMissingTranslation({ language, path })
     }
 
     return result
@@ -23,8 +27,11 @@ export function useI18nLanguage() {
   return context.language
 }
 
-export function I18nProvider({ value, language, children }) {
-  const providerValue = React.useMemo(() => ({ value, language }), [value, language])
+export function I18nProvider({ value, language, logMissingTranslation = defaultLogMissingTranslation, children }) {
+  const providerValue = React.useMemo(
+    () => ({ value, language, logMissingTranslation }), 
+    [value, language, logMissingTranslation]
+  )
 
   return (
     <i18nContext.Provider value={providerValue}>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const i18nContext = React.createContext(null)
 
 const defaultLogMissingTranslation = ({ language, path }) => { 
-  console.console.warn(`Missing translation (${language}): ${path}`)
+  console.warn(`Missing translation (${language}): ${path}`)
 }
 
 export function useI18n(...i18nPathSegments) {

--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ const i18n = {
 |----------------|-------------------------------------------------------------------------------|
 | `value`        | The i18n object to use. |
 | `language`     | _Optional._ <br />When a language is given, normalization will be attempted at the leave nodes. E.g.: given the language `en` this means a leafnode with the shape `{ en: 'countries', nl: 'landen' }` will be normalized to just `'countries'`. |
+| `logMissingTranslation`     | _Optional._ (default: `console.warn`)<br />If you want to change how missing translations are logged, you can provide your own `logMissingTranslation` function. This function is called with an object of the shape: `{ language, path }`. |
 
 The provided i18n object may be a deeply nested object, optionally containing arrays. Values don't have to be strings, you can also provide numbers, functions or React elements (see the example i18n object under [usage](#usage))
 


### PR DESCRIPTION
Motivation for this feature are all the `Missing translation (undefined): {key}` warnings you get when you use this library in a PHP project, where the first render does not have access to the SSR props (which contain the translations). In this specific situation, you could provide a logger that only warns if translations are available:

```js
<I18nProvider value={i18n} {...{ language, logMissingTranslation }}/>

function logMissingTranslation({ language, path }) {
  if (phpProps.i18n) console.warn(`Missing translation (${language}): ${path}`)
}
```